### PR TITLE
Update action to make releases

### DIFF
--- a/.github/workflows/export-bugsigdb.yml
+++ b/.github/workflows/export-bugsigdb.yml
@@ -123,6 +123,7 @@ jobs:
         run: |
           cd $GITHUB_WORKSPACE/BugSigDBExports
           echo "Switch to the release branch"
+          git fetch origin release
           git switch release
 
       - name: Count new rows

--- a/.github/workflows/export-bugsigdb.yml
+++ b/.github/workflows/export-bugsigdb.yml
@@ -3,16 +3,28 @@ on:
     - cron: "55 * * * *" # UTC Time
   workflow_dispatch:
     inputs:
-      validate:
-        description: "Validate and filter"
+      release:
+        description: "Create a new release"
         required: false
         default: 'false'
         type: choice
         options:
           - 'false'
           - 'true'
-      branch:
-        description: "Create a branch"
+      dryrun:
+        description: "Dry run"
+        required: false
+        default: 'true'
+        type: choice
+        options:
+          - 'false'
+          - 'true'
+      version:
+        description: "Specify version tag"
+        required: false
+        type: string
+      news:
+        description: "Enter NEWS file updates"
         required: false
         type: string
 
@@ -25,10 +37,30 @@ jobs:
 
     steps:
 
+      - name: Validate version format
+        id: validate_version
+        if: ${{ github.event.inputs.release == 'true' }}
+        run: |
+          if [ -z "${{ github.event.inputs.version }}" ]; then
+            echo "Version is required when release is true"
+            exit 1
+          fi
+          TAG="${{ github.event.inputs.version }}"
+          if [[ ! "$TAG" =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+            echo "Invalid tag format. Must be v[major].[minor].[patch] e.g. v1.3.1"
+            exit 1
+          fi
+          if git ls-remote --tags origin "$TAG" | grep -q "$TAG"; then
+            echo "Tag $TAG already exists"
+            exit 1
+          fi
+          echo "VERSION=$TAG" >> $GITHUB_ENV
+
       - name: Checkout BugSigDBExports
         uses: actions/checkout@v3
         with:
           path: BugSigDBExports
+          fetch-depth: 1
 
       - name: Install BugSigDBExports dependencies
         run: |
@@ -47,11 +79,12 @@ jobs:
           git config user.email "actions@github.com"
 
       - name: Export BugSigDB
+        id: export
         run: |
           BUGSIGDB_TIMESTAMP="$(date -u +%Y-%m-%d_%H:%M_UTC)"
           echo "BUGSIGDB_TIMESTAMP=$BUGSIGDB_TIMESTAMP" >> $GITHUB_ENV
           echo $BUGSIGDB_TIMESTAMP
-          Rscript $GITHUB_WORKSPACE/BugSigDBExports/inst/scripts/dump_release.R $BUGSIGDB_TIMESTAMP $GITHUB_WORKSPACE/BugSigDBExports ${{ github.event.inputs.validate }}
+          Rscript $GITHUB_WORKSPACE/BugSigDBExports/inst/scripts/dump_release.R $BUGSIGDB_TIMESTAMP $GITHUB_WORKSPACE/BugSigDBExports ${{ github.event.inputs.release }}
           mv *csv $GITHUB_WORKSPACE/BugSigDBExports
         timeout-minutes: 10
 
@@ -84,25 +117,47 @@ jobs:
                       row.names = FALSE)
         shell: Rscript {0}
 
-      - name: Check if branch was set and exists and if data must be validated
-        id: create_branch
-        if: ${{ github.event.inputs.branch != '' && github.event.inputs.validate == 'true' }}
+      - name: Create release
+        id: create_release
+        if: ${{ github.event.inputs.release == 'true' }}
         run: |
           cd $GITHUB_WORKSPACE/BugSigDBExports
-          if git ls-remote --exit-code --heads origin "${{ github.event.inputs.branch }}"; then
-            echo "Branch already exists"
-            exit 1
-          else
-            echo "Create and switch to new branch"
-            git switch -c ${{ github.event.inputs.branch }}
-            echo "make_pr=true" >> $GITHUB_OUTPUT
+          echo "Switch to the release branch"
+          git switch release
+
+      - name: Count new rows
+        if: ${{ github.event.inputs.release == 'true' }}
+        run: |
+          cd $GITHUB_WORKSPACE/BugSigDBExports
+          ROW_COUNTS=""
+          for file in full_dump.csv *.gmt; do
+            OLD_ROWS=$(git show origin/release:$file | tail -n +2 | wc -l)
+            NEW_ROWS=$(tail -n +2 $file | wc -l)
+            DIFF=$((NEW_ROWS - OLD_ROWS))
+            echo "$file: $OLD_ROWS -> $NEW_ROWS (+$DIFF)"
+            ROW_COUNTS="$ROW_COUNTS\n    o $file: $NEW_ROWS rows ($DIFF new)"
+          done
+          echo "ROW_COUNTS<<EOF" >> $GITHUB_ENV
+          echo -e "$ROW_COUNTS" >> $GITHUB_ENV
+          echo "EOF" >> $GITHUB_ENV
+
+      - name: Update NEWS
+        if: ${{ github.event.inputs.release == 'true' }}
+        run: |
+          cd $GITHUB_WORKSPACE/BugSigDBExports
+          NEWS_CONTENT="CHANGES IN VERSION ${{ github.event.inputs.version }}\n------------------------\n\nNEW DATA\n\n${{ env.ROW_COUNTS }}\n"
+          if [ -n "${{ github.event.inputs.news }}" ]; then
+            NEWS_CONTENT="$NEWS_CONTENT\n${{ github.event.inputs.news }}\n"
           fi
+          NEWS_CONTENT="$NEWS_CONTENT\n"
+          printf "$NEWS_CONTENT" | cat - NEWS > NEWS.tmp && mv NEWS.tmp NEWS
 
       - name: Commit Exports
         id: commit_exports
+        if: ${{ github.event.inputs.dryrun != 'true' }}
         run: |
           cd $GITHUB_WORKSPACE/BugSigDBExports
-          for export in `find . -type f -iname \*.gmt -o -iname \*.csv`
+          for export in `find . -type f -iname \*.gmt -o -iname \*.csv -o -iname NEWS`
           do
             export=$(echo $export | sed 's/\.\///g')
             git_diff=$(git diff --numstat $export | sed -e 's/\t//g')
@@ -117,7 +172,11 @@ jobs:
           has_updates=$(git diff --cached --shortstat)
           if [ -n "$has_updates" ]; then
             git add file_size.csv
-            git commit -m "Hourly export update"
+            COMMIT_MSG="Hourly export update"
+            if [ "${{ github.event.inputs.release }}" == "true" ]; then
+              COMMIT_MSG="Release ${{ github.event.inputs.version }}"
+            fi
+            git commit -m "$COMMIT_MSG"
             git push -u origin HEAD
             echo "pushed=true" >> $GITHUB_OUTPUT
           else
@@ -125,18 +184,28 @@ jobs:
             echo "pushed=false" >> $GITHUB_OUTPUT
           fi
 
-      - name: Make PR
-        if: ${{ steps.create_branch.outputs.make_pr == 'true' && steps.commit_exports.outputs.pushed == 'true' }}
+      - name: Tag release
+        if: ${{ github.event.inputs.release == 'true' && github.event.inputs.dryrun == 'false' && github.event.inputs.version != '' }}
         run: |
-          curl -X POST \
-            -H "Authorization: token ${{ secrets.GITHUB_TOKEN }}" \
-            -H "Accept: application/vnd.github.v3+json" \
-            https://api.github.com/repos/${{ github.repository }}/pulls \
-            -d '{
-              "title": "Release candidate",
-              "head": "${{ github.event.inputs.branch }}",
-              "base": "devel",
-              "body": "Please review the release candidate and close. (Do not merge.)",
-              "draft": true
-            }'
-          echo "PR opened for review"
+          cd $GITHUB_WORKSPACE/BugSigDBExports
+          git tag ${{ github.event.inputs.version }}
+          git push origin ${{ github.event.inputs.version }}
+
+      - name: Upload release candidate artifacts
+        if: ${{ github.event.inputs.dryrun == 'true' }}
+        uses: actions/upload-artifact@v4
+        with:
+          name: candidate
+          path: |
+            ${{ github.workspace }}/BugSigDBExports/*.csv
+            ${{ github.workspace }}/BugSigDBExports/*.gmt
+            ${{ github.workspace }}/BugSigDBExports/NEWS
+          retention-days: 90
+
+      - name: Post run summary
+        if: ${{ github.event.inputs.release == 'true' && github.event.inputs.dryrun == 'true' }}
+        run: |
+          echo "## Release candidate ${{ github.event.inputs.version }}" >> $GITHUB_STEP_SUMMARY
+          echo "Artifacts are available for download on this run's page." >> $GITHUB_STEP_SUMMARY
+          echo "If the data looks good, trigger the workflow again with \`release\` set to \`true\`, \`dryrun\` set to \`false\` and the same tag \`${{ github.event.inputs.version }}\`." >> $GITHUB_STEP_SUMMARY
+          echo "Add content to NEWS with \`news\`." >> $GITHUB_STEP_SUMMARY

--- a/.github/workflows/export-bugsigdb.yml
+++ b/.github/workflows/export-bugsigdb.yml
@@ -233,6 +233,14 @@ jobs:
           git tag ${{ github.event.inputs.version }}
           git push origin ${{ github.event.inputs.version }}
 
+      - name: Stage artifacts
+        if: ${{ github.event.inputs.dryrun == 'true' }}
+        run: |
+          mkdir -p /tmp/artifacts
+          cp $GITHUB_WORKSPACE/BugSigDBExports/full_dump.csv /tmp/artifacts/
+          cp $GITHUB_WORKSPACE/BugSigDBExports/*.gmt /tmp/artifacts/
+          cp $GITHUB_WORKSPACE/BugSigDBExports-release/NEWS /tmp/artifacts/
+
       - name: Upload release candidate artifacts
         if: ${{ github.event.inputs.dryrun == 'true' }}
         uses: actions/upload-artifact@v4
@@ -248,6 +256,6 @@ jobs:
         if: ${{ github.event.inputs.release == 'true' && github.event.inputs.dryrun == 'true' }}
         run: |
           echo "## Release candidate ${{ github.event.inputs.version }}" >> $GITHUB_STEP_SUMMARY
-          echo "Artifacts are available for download on this run's page." >> $GITHUB_STEP_SUMMARY
-          echo "If the data looks good, trigger the workflow again with \`release\` set to \`true\`, \`dryrun\` set to \`false\` and the same tag \`${{ github.event.inputs.version }}\`." >> $GITHUB_STEP_SUMMARY
-          echo "Add content to NEWS with \`news\`." >> $GITHUB_STEP_SUMMARY
+          echo "* Artifacts are available for download on this run's page." >> $GITHUB_STEP_SUMMARY
+          echo "* If the data looks good, trigger the workflow again with \`release\` set to \`true\`, \`dryrun\` set to \`false\` and the same tag \`${{ github.event.inputs.version }}\`." >> $GITHUB_STEP_SUMMARY
+          echo "* Add content to NEWS with \`news\`." >> $GITHUB_STEP_SUMMARY

--- a/.github/workflows/export-bugsigdb.yml
+++ b/.github/workflows/export-bugsigdb.yml
@@ -88,16 +88,6 @@ jobs:
           mv *csv $GITHUB_WORKSPACE/BugSigDBExports
         timeout-minutes: 10
 
-      - name: Test Study and Condition for NAs
-        run: |
-          library(R.utils)
-          library(testthat)
-          github_workspace <- Sys.getenv("GITHUB_WORKSPACE")
-          setwd(file.path(github_workspace, "BugSigDBExports"))
-          bsdb <- read.csv("full_dump.csv", skip = 1)
-          expect_true(all(!is.na(bsdb$Study)))
-        shell: Rscript {0}
-
       - name: Track file growth
         run: |
           library(R.utils)
@@ -116,6 +106,35 @@ jobs:
                       col.names = FALSE,
                       row.names = FALSE)
         shell: Rscript {0}
+
+      - name: Check for dramatic row count drop and truncate
+        run: |
+          cd $GITHUB_WORKSPACE/BugSigDBExports
+          Rscript -e "
+            df <- read.csv('file_size.csv', header = FALSE)
+            full_dump_col <- which(as.character(df[1,]) == 'full_dump.csv')
+            if (length(full_dump_col) > 0 && nrow(df) > 1) {
+              current <- as.numeric(df[nrow(df), full_dump_col])
+              previous <- as.numeric(df[nrow(df)-1, full_dump_col])
+              drop_pct <- (previous - current) / previous * 100
+              if (drop_pct > 10) {
+                cat(sprintf('DROP_DETECTED=true\nDROP_PCT=%.1f\n', drop_pct),
+                    file = Sys.getenv('GITHUB_ENV'), append = TRUE)
+              }
+            }
+          "
+
+      - name: Open issue on dramatic drop
+        if: ${{ env.DROP_DETECTED == 'true' }}
+        run: |
+          curl -X POST \
+            -H "Authorization: token ${{ secrets.GITHUB_TOKEN }}" \
+            -H "Accept: application/vnd.github.v3+json" \
+            https://api.github.com/repos/${{ github.repository }}/issues \
+            -d "{
+              \"title\": \"Warning: dramatic row count drop detected\",
+              \"body\": \"The full_dump.csv row count dropped by ${{ env.DROP_PCT }}% in the latest export. This may indicate a network issue during download. Please check the [latest run](https://github.com/${{ github.repository }}/actions).\"
+            }"
 
       - name: Create release
         id: create_release

--- a/.github/workflows/export-bugsigdb.yml
+++ b/.github/workflows/export-bugsigdb.yml
@@ -120,6 +120,12 @@ jobs:
                       append = TRUE,
                       col.names = FALSE,
                       row.names = FALSE)
+          # Keep only last 30 days
+          df <- read.csv("file_size.csv", header=FALSE)
+          df$date <- as.Date(df[,1], format="%Y-%m-%d")
+          df <- df[df$date >= Sys.Date() - 30, ]
+          df$date <- NULL
+          write.table(df, "file_size.csv", col.names=FALSE, row.names=FALSE)
         shell: Rscript {0}
 
       - name: Check for dramatic row count drop
@@ -184,7 +190,7 @@ jobs:
         if: ${{ github.event.inputs.release == 'true' }}
         run: |
           cd $GITHUB_WORKSPACE/BugSigDBExports-release
-          NEWS_CONTENT="CHANGES IN VERSION ${{ github.event.inputs.version }}\n------------------------\n\nNEW DATA\n\n${{ env.ROW_COUNTS }}\n"
+          NEWS_CONTENT="CHANGES IN VERSION ${{ github.event.inputs.version }}\n------------------------\nNEW DATA\n\n${{ env.ROW_COUNTS }}\n"
           if [ -n "${{ github.event.inputs.news }}" ]; then
             NEWS_CONTENT="$NEWS_CONTENT\n${{ github.event.inputs.news }}\n"
           fi
@@ -216,7 +222,7 @@ jobs:
           if [ -n "$has_updates" ]; then
             git add file_size.csv
             COMMIT_MSG="Hourly export update"
-            if [ "${{ github.event.inputs.release }}" == "true" ]; then
+            if [ "${{ github.event.inputs.release }}" = "true" ]; then
               COMMIT_MSG="Release ${{ github.event.inputs.version }}"
             fi
             git commit -m "$COMMIT_MSG"
@@ -233,6 +239,22 @@ jobs:
           cd $GITHUB_WORKSPACE/BugSigDBExports-release
           git tag ${{ github.event.inputs.version }}
           git push origin ${{ github.event.inputs.version }}
+
+      - name: Create GitHub Release
+        if: ${{ github.event.inputs.release == 'true' && github.event.inputs.dryrun == 'false' && github.event.inputs.version != '' }}
+        run: |
+          NEWS_BODY=$(sed -n "/^CHANGES IN VERSION ${{ github.event.inputs.version }}/,/^CHANGES IN VERSION/{ /^CHANGES IN VERSION ${{ github.event.inputs.version }}/d; /^CHANGES IN VERSION/d; p }" $GITHUB_WORKSPACE/BugSigDBExports-release/NEWS)
+          curl -X POST \
+            -H "Authorization: token ${{ secrets.GITHUB_TOKEN }}" \
+            -H "Accept: application/vnd.github.v3+json" \
+            https://api.github.com/repos/${{ github.repository }}/releases \
+            -d "{
+              \"tag_name\": \"${{ github.event.inputs.version }}\",
+              \"name\": \"${{ github.event.inputs.version }}\",
+              \"body\": $(echo "$NEWS_BODY" | python3 -c 'import json,sys; print(json.dumps(sys.stdin.read()))'),
+              \"draft\": false,
+              \"prerelease\": false
+            }"
 
       - name: Stage artifacts
         if: ${{ github.event.inputs.release == 'true' && github.event.inputs.dryrun == 'true' }}
@@ -258,4 +280,3 @@ jobs:
           echo "* Artifacts are available for download on this run's page." >> $GITHUB_STEP_SUMMARY
           echo "* If the data looks good, trigger the workflow again with \`release\` set to \`true\`, \`dryrun\` set to \`false\` and the same tag \`${{ github.event.inputs.version }}\`." >> $GITHUB_STEP_SUMMARY
           echo "* Add content to NEWS with \`news\`." >> $GITHUB_STEP_SUMMARY
-

--- a/.github/workflows/export-bugsigdb.yml
+++ b/.github/workflows/export-bugsigdb.yml
@@ -143,7 +143,9 @@ jobs:
           cd $GITHUB_WORKSPACE/BugSigDBExports
           echo "Switch to the release branch"
           git fetch origin release
+          git stash
           git switch release
+          git stash pop
 
       - name: Count new rows
         if: ${{ github.event.inputs.release == 'true' }}

--- a/.github/workflows/export-bugsigdb.yml
+++ b/.github/workflows/export-bugsigdb.yml
@@ -2,31 +2,6 @@ on:
   schedule:
     - cron: "55 * * * *" # UTC Time
   workflow_dispatch:
-    inputs:
-      release:
-        description: "Create a new release"
-        required: false
-        default: 'false'
-        type: choice
-        options:
-          - 'false'
-          - 'true'
-      dryrun:
-        description: "Dry run (only applies when release is true)"
-        required: false
-        default: 'true'
-        type: choice
-        options:
-          - 'false'
-          - 'true'
-      version:
-        description: "Specify version tag"
-        required: false
-        type: string
-      news:
-        description: "Enter NEWS file updates"
-        required: false
-        type: string
 
 name: Export BugSigDB
 
@@ -37,37 +12,10 @@ jobs:
 
     steps:
 
-      - name: Validate version format
-        id: validate_version
-        if: ${{ github.event.inputs.release == 'true' }}
-        run: |
-          if [ -z "${{ github.event.inputs.version }}" ]; then
-            echo "Version is required when release is true"
-            exit 1
-          fi
-          TAG="${{ github.event.inputs.version }}"
-          if [[ ! "$TAG" =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
-            echo "Invalid tag format. Must be v[major].[minor].[patch] e.g. v1.3.1"
-            exit 1
-          fi
-          if git ls-remote --tags origin "$TAG" | grep -q "$TAG"; then
-            echo "Tag $TAG already exists"
-            exit 1
-          fi
-          echo "VERSION=$TAG" >> $GITHUB_ENV
-
       - name: Checkout BugSigDBExports
         uses: actions/checkout@v3
         with:
           path: BugSigDBExports
-          fetch-depth: 1
-
-      - name: Checkout BugSigDBExports release branch
-        if: ${{ github.event.inputs.release == 'true' }}
-        uses: actions/checkout@v3
-        with:
-          ref: release
-          path: BugSigDBExports-release
           fetch-depth: 1
 
       - name: Install BugSigDBExports dependencies
@@ -86,20 +34,13 @@ jobs:
           git config user.name "GitHub Actions Bot"
           git config user.email "actions@github.com"
 
-      - name: Setup git config for release
-        if: ${{ github.event.inputs.release == 'true' }}
-        run: |
-          cd $GITHUB_WORKSPACE/BugSigDBExports-release
-          git config user.name "GitHub Actions Bot"
-          git config user.email "actions@github.com"
-
       - name: Export BugSigDB
         id: export
         run: |
           BUGSIGDB_TIMESTAMP="$(date -u +%Y-%m-%d_%H:%M_UTC)"
           echo "BUGSIGDB_TIMESTAMP=$BUGSIGDB_TIMESTAMP" >> $GITHUB_ENV
           echo $BUGSIGDB_TIMESTAMP
-          Rscript $GITHUB_WORKSPACE/BugSigDBExports/inst/scripts/dump_release.R $BUGSIGDB_TIMESTAMP $GITHUB_WORKSPACE/BugSigDBExports ${{ github.event.inputs.release }}
+          Rscript $GITHUB_WORKSPACE/BugSigDBExports/inst/scripts/dump_release.R $BUGSIGDB_TIMESTAMP $GITHUB_WORKSPACE/BugSigDBExports false
           mv *csv $GITHUB_WORKSPACE/BugSigDBExports
         timeout-minutes: 10
 
@@ -157,56 +98,11 @@ jobs:
               \"body\": \"The full_dump.csv row count dropped by ${{ env.DROP_PCT }}% in the latest export. This may indicate a network issue during download. Please check the [latest run](https://github.com/${{ github.repository }}/actions).\"
             }"
 
-      - name: Count new rows
-        if: ${{ github.event.inputs.release == 'true' }}
-        run: |
-          cd $GITHUB_WORKSPACE/BugSigDBExports
-          ROW_COUNTS=""
-          for file in full_dump.csv bugsigdb_signatures_*.gmt; do
-            OLD_ROWS=$(tail -n +2 $GITHUB_WORKSPACE/BugSigDBExports-release/$file | wc -l)
-            NEW_ROWS=$(tail -n +2 $GITHUB_WORKSPACE/BugSigDBExports/$file | wc -l)
-            DIFF=$((NEW_ROWS - OLD_ROWS))
-            if [ $DIFF -ge 0 ]; then
-              DIFF_STR="+$DIFF"
-            else
-              DIFF_STR="$DIFF"
-            fi
-            echo "$file: $OLD_ROWS -> $NEW_ROWS ($DIFF_STR)"
-            ROW_COUNTS="$ROW_COUNTS\n    o $file: $NEW_ROWS rows ($DIFF_STR)"
-          done
-          echo "ROW_COUNTS<<EOF" >> $GITHUB_ENV
-          printf "$ROW_COUNTS" >> $GITHUB_ENV
-          echo "" >> $GITHUB_ENV
-          echo "EOF" >> $GITHUB_ENV
-
-      - name: Copy exports to release
-        if: ${{ github.event.inputs.release == 'true' }}
-        run: |
-          cp $GITHUB_WORKSPACE/BugSigDBExports/full_dump.csv $GITHUB_WORKSPACE/BugSigDBExports-release/
-          cp $GITHUB_WORKSPACE/BugSigDBExports/*.gmt $GITHUB_WORKSPACE/BugSigDBExports-release/
-          cp $GITHUB_WORKSPACE/BugSigDBExports/file_size.csv $GITHUB_WORKSPACE/BugSigDBExports-release/
-
-      - name: Update NEWS
-        if: ${{ github.event.inputs.release == 'true' }}
-        run: |
-          cd $GITHUB_WORKSPACE/BugSigDBExports-release
-          NEWS_CONTENT="CHANGES IN VERSION ${{ github.event.inputs.version }}\n------------------------\nNEW DATA\n\n${{ env.ROW_COUNTS }}\n"
-          if [ -n "${{ github.event.inputs.news }}" ]; then
-            NEWS_CONTENT="$NEWS_CONTENT\n${{ github.event.inputs.news }}\n"
-          fi
-          NEWS_CONTENT="$NEWS_CONTENT\n"
-          printf "$NEWS_CONTENT" | cat - NEWS > NEWS.tmp && mv NEWS.tmp NEWS
-
       - name: Commit Exports
         id: commit_exports
-        if: ${{ github.event.inputs.dryrun != 'true' }}
         run: |
-          WORK_DIR=$GITHUB_WORKSPACE/BugSigDBExports
-          if [ "${{ github.event.inputs.release }}" = "true" ]; then
-            WORK_DIR=$GITHUB_WORKSPACE/BugSigDBExports-release
-          fi
-          cd $WORK_DIR
-          for export in `find . -type f -iname \*.gmt -o -iname \*.csv -o -iname NEWS`
+          cd $GITHUB_WORKSPACE/BugSigDBExports
+          for export in `find . -type f -iname \*.gmt -o -iname \*.csv`
           do
             export=$(echo $export | sed 's/\.\///g')
             git_diff=$(git diff --numstat $export | sed -e 's/\t//g')
@@ -221,62 +117,10 @@ jobs:
           has_updates=$(git diff --cached --shortstat)
           if [ -n "$has_updates" ]; then
             git add file_size.csv
-            COMMIT_MSG="Hourly export update"
-            if [ "${{ github.event.inputs.release }}" = "true" ]; then
-              COMMIT_MSG="Release ${{ github.event.inputs.version }}"
-            fi
-            git commit -m "$COMMIT_MSG"
+            git commit -m "Hourly export update"
             git push -u origin HEAD
             echo "pushed=true" >> $GITHUB_OUTPUT
           else
             echo "No content changes to commit"
             echo "pushed=false" >> $GITHUB_OUTPUT
           fi
-
-      - name: Tag release
-        if: ${{ github.event.inputs.release == 'true' && github.event.inputs.dryrun == 'false' && github.event.inputs.version != '' }}
-        run: |
-          cd $GITHUB_WORKSPACE/BugSigDBExports-release
-          git tag ${{ github.event.inputs.version }}
-          git push origin ${{ github.event.inputs.version }}
-
-      - name: Create GitHub Release
-        if: ${{ github.event.inputs.release == 'true' && github.event.inputs.dryrun == 'false' && github.event.inputs.version != '' }}
-        run: |
-          NEWS_BODY=$(sed -n "/^CHANGES IN VERSION ${{ github.event.inputs.version }}/,/^CHANGES IN VERSION/{ /^CHANGES IN VERSION ${{ github.event.inputs.version }}/d; /^CHANGES IN VERSION/d; p }" $GITHUB_WORKSPACE/BugSigDBExports-release/NEWS)
-          curl -X POST \
-            -H "Authorization: token ${{ secrets.GITHUB_TOKEN }}" \
-            -H "Accept: application/vnd.github.v3+json" \
-            https://api.github.com/repos/${{ github.repository }}/releases \
-            -d "{
-              \"tag_name\": \"${{ github.event.inputs.version }}\",
-              \"name\": \"${{ github.event.inputs.version }}\",
-              \"body\": $(echo "$NEWS_BODY" | python3 -c 'import json,sys; print(json.dumps(sys.stdin.read()))'),
-              \"draft\": false,
-              \"prerelease\": false
-            }"
-
-      - name: Stage artifacts
-        if: ${{ github.event.inputs.release == 'true' && github.event.inputs.dryrun == 'true' }}
-        run: |
-          mkdir -p /tmp/artifacts
-          cp $GITHUB_WORKSPACE/BugSigDBExports-release/full_dump.csv /tmp/artifacts/
-          cp $GITHUB_WORKSPACE/BugSigDBExports-release/bugsigdb_signatures_*.gmt /tmp/artifacts/
-          cp $GITHUB_WORKSPACE/BugSigDBExports-release/NEWS /tmp/artifacts/
-          ls /tmp/artifacts/
-
-      - name: Upload release candidate artifacts
-        if: ${{ github.event.inputs.release == 'true' && github.event.inputs.dryrun == 'true' }}
-        uses: actions/upload-artifact@v4
-        with:
-          name: candidate
-          path: /tmp/artifacts/
-          retention-days: 90
-
-      - name: Post run summary
-        if: ${{ github.event.inputs.release == 'true' && github.event.inputs.dryrun == 'true' }}
-        run: |
-          echo "## Release candidate ${{ github.event.inputs.version }}" >> $GITHUB_STEP_SUMMARY
-          echo "* Artifacts are available for download on this run's page." >> $GITHUB_STEP_SUMMARY
-          echo "* If the data looks good, trigger the workflow again with \`release\` set to \`true\`, \`dryrun\` set to \`false\` and the same tag \`${{ github.event.inputs.version }}\`." >> $GITHUB_STEP_SUMMARY
-          echo "* Add content to NEWS with \`news\`." >> $GITHUB_STEP_SUMMARY

--- a/.github/workflows/export-bugsigdb.yml
+++ b/.github/workflows/export-bugsigdb.yml
@@ -12,7 +12,7 @@ on:
           - 'false'
           - 'true'
       dryrun:
-        description: "Dry run"
+        description: "Dry run (only applies when release is true)"
         required: false
         default: 'true'
         type: choice
@@ -151,18 +151,12 @@ jobs:
               \"body\": \"The full_dump.csv row count dropped by ${{ env.DROP_PCT }}% in the latest export. This may indicate a network issue during download. Please check the [latest run](https://github.com/${{ github.repository }}/actions).\"
             }"
 
-      - name: Copy exports to release
-        if: ${{ github.event.inputs.release == 'true' }}
-        run: |
-          cp $GITHUB_WORKSPACE/BugSigDBExports/*.csv $GITHUB_WORKSPACE/BugSigDBExports-release/
-          cp $GITHUB_WORKSPACE/BugSigDBExports/*.gmt $GITHUB_WORKSPACE/BugSigDBExports-release/
-
       - name: Count new rows
         if: ${{ github.event.inputs.release == 'true' }}
         run: |
           cd $GITHUB_WORKSPACE/BugSigDBExports
           ROW_COUNTS=""
-          for file in full_dump.csv *.gmt; do
+          for file in full_dump.csv bugsigdb_signatures_*.gmt; do
             OLD_ROWS=$(tail -n +2 $GITHUB_WORKSPACE/BugSigDBExports-release/$file | wc -l)
             NEW_ROWS=$(tail -n +2 $GITHUB_WORKSPACE/BugSigDBExports/$file | wc -l)
             DIFF=$((NEW_ROWS - OLD_ROWS))
@@ -178,6 +172,13 @@ jobs:
           printf "$ROW_COUNTS" >> $GITHUB_ENV
           echo "" >> $GITHUB_ENV
           echo "EOF" >> $GITHUB_ENV
+
+      - name: Copy exports to release
+        if: ${{ github.event.inputs.release == 'true' }}
+        run: |
+          cp $GITHUB_WORKSPACE/BugSigDBExports/full_dump.csv $GITHUB_WORKSPACE/BugSigDBExports-release/
+          cp $GITHUB_WORKSPACE/BugSigDBExports/*.gmt $GITHUB_WORKSPACE/BugSigDBExports-release/
+          cp $GITHUB_WORKSPACE/BugSigDBExports/file_size.csv $GITHUB_WORKSPACE/BugSigDBExports-release/
 
       - name: Update NEWS
         if: ${{ github.event.inputs.release == 'true' }}
@@ -195,7 +196,7 @@ jobs:
         if: ${{ github.event.inputs.dryrun != 'true' }}
         run: |
           WORK_DIR=$GITHUB_WORKSPACE/BugSigDBExports
-          if [ "${{ github.event.inputs.release }}" == "true" ]; then
+          if [ "${{ github.event.inputs.release }}" = "true" ]; then
             WORK_DIR=$GITHUB_WORKSPACE/BugSigDBExports-release
           fi
           cd $WORK_DIR
@@ -234,22 +235,20 @@ jobs:
           git push origin ${{ github.event.inputs.version }}
 
       - name: Stage artifacts
-        if: ${{ github.event.inputs.dryrun == 'true' }}
+        if: ${{ github.event.inputs.release == 'true' && github.event.inputs.dryrun == 'true' }}
         run: |
           mkdir -p /tmp/artifacts
-          cp $GITHUB_WORKSPACE/BugSigDBExports/full_dump.csv /tmp/artifacts/
-          cp $GITHUB_WORKSPACE/BugSigDBExports/*.gmt /tmp/artifacts/
+          cp $GITHUB_WORKSPACE/BugSigDBExports-release/full_dump.csv /tmp/artifacts/
+          cp $GITHUB_WORKSPACE/BugSigDBExports-release/bugsigdb_signatures_*.gmt /tmp/artifacts/
           cp $GITHUB_WORKSPACE/BugSigDBExports-release/NEWS /tmp/artifacts/
+          ls /tmp/artifacts/
 
       - name: Upload release candidate artifacts
-        if: ${{ github.event.inputs.dryrun == 'true' }}
+        if: ${{ github.event.inputs.release == 'true' && github.event.inputs.dryrun == 'true' }}
         uses: actions/upload-artifact@v4
         with:
           name: candidate
-          path: |
-            ${{ github.workspace }}/BugSigDBExports/*.csv
-            ${{ github.workspace }}/BugSigDBExports/*.gmt
-            ${{ github.workspace }}/BugSigDBExports/NEWS
+          path: /tmp/artifacts/
           retention-days: 90
 
       - name: Post run summary
@@ -259,3 +258,4 @@ jobs:
           echo "* Artifacts are available for download on this run's page." >> $GITHUB_STEP_SUMMARY
           echo "* If the data looks good, trigger the workflow again with \`release\` set to \`true\`, \`dryrun\` set to \`false\` and the same tag \`${{ github.event.inputs.version }}\`." >> $GITHUB_STEP_SUMMARY
           echo "* Add content to NEWS with \`news\`." >> $GITHUB_STEP_SUMMARY
+

--- a/.github/workflows/export-bugsigdb.yml
+++ b/.github/workflows/export-bugsigdb.yml
@@ -160,16 +160,23 @@ jobs:
       - name: Count new rows
         if: ${{ github.event.inputs.release == 'true' }}
         run: |
+          cd $GITHUB_WORKSPACE/BugSigDBExports
           ROW_COUNTS=""
           for file in full_dump.csv *.gmt; do
             OLD_ROWS=$(tail -n +2 $GITHUB_WORKSPACE/BugSigDBExports-release/$file | wc -l)
             NEW_ROWS=$(tail -n +2 $GITHUB_WORKSPACE/BugSigDBExports/$file | wc -l)
             DIFF=$((NEW_ROWS - OLD_ROWS))
-            echo "$file: $OLD_ROWS -> $NEW_ROWS (+$DIFF)"
-            ROW_COUNTS="$ROW_COUNTS\n    o $file: $NEW_ROWS rows ($DIFF new)"
+            if [ $DIFF -ge 0 ]; then
+              DIFF_STR="+$DIFF"
+            else
+              DIFF_STR="$DIFF"
+            fi
+            echo "$file: $OLD_ROWS -> $NEW_ROWS ($DIFF_STR)"
+            ROW_COUNTS="$ROW_COUNTS\n    o $file: $NEW_ROWS rows ($DIFF_STR)"
           done
           echo "ROW_COUNTS<<EOF" >> $GITHUB_ENV
-          echo -e "$ROW_COUNTS" >> $GITHUB_ENV
+          printf "$ROW_COUNTS" >> $GITHUB_ENV
+          echo "" >> $GITHUB_ENV
           echo "EOF" >> $GITHUB_ENV
 
       - name: Update NEWS

--- a/.github/workflows/export-bugsigdb.yml
+++ b/.github/workflows/export-bugsigdb.yml
@@ -62,6 +62,14 @@ jobs:
           path: BugSigDBExports
           fetch-depth: 1
 
+      - name: Checkout BugSigDBExports release branch
+        if: ${{ github.event.inputs.release == 'true' }}
+        uses: actions/checkout@v3
+        with:
+          ref: release
+          path: BugSigDBExports-release
+          fetch-depth: 1
+
       - name: Install BugSigDBExports dependencies
         run: |
           pkgs <- c('rvest', 'readr', 'plyr', 'BiocFileCache', 'R.utils', 'testthat', 'stringr', 'lubridate', 'dplyr')
@@ -74,7 +82,14 @@ jobs:
 
       - name: Setup git config
         run: |
-          cd $GITHUB_WORKSPACE/BugSigDBExports # Because we need to be in a repository
+          cd $GITHUB_WORKSPACE/BugSigDBExports
+          git config user.name "GitHub Actions Bot"
+          git config user.email "actions@github.com"
+
+      - name: Setup git config for release
+        if: ${{ github.event.inputs.release == 'true' }}
+        run: |
+          cd $GITHUB_WORKSPACE/BugSigDBExports-release
           git config user.name "GitHub Actions Bot"
           git config user.email "actions@github.com"
 
@@ -107,7 +122,7 @@ jobs:
                       row.names = FALSE)
         shell: Rscript {0}
 
-      - name: Check for dramatic row count drop and truncate
+      - name: Check for dramatic row count drop
         run: |
           cd $GITHUB_WORKSPACE/BugSigDBExports
           Rscript -e "
@@ -136,25 +151,19 @@ jobs:
               \"body\": \"The full_dump.csv row count dropped by ${{ env.DROP_PCT }}% in the latest export. This may indicate a network issue during download. Please check the [latest run](https://github.com/${{ github.repository }}/actions).\"
             }"
 
-      - name: Create release
-        id: create_release
+      - name: Copy exports to release
         if: ${{ github.event.inputs.release == 'true' }}
         run: |
-          cd $GITHUB_WORKSPACE/BugSigDBExports
-          echo "Switch to the release branch"
-          git fetch origin release
-          git stash
-          git switch release
-          git stash pop
+          cp $GITHUB_WORKSPACE/BugSigDBExports/*.csv $GITHUB_WORKSPACE/BugSigDBExports-release/
+          cp $GITHUB_WORKSPACE/BugSigDBExports/*.gmt $GITHUB_WORKSPACE/BugSigDBExports-release/
 
       - name: Count new rows
         if: ${{ github.event.inputs.release == 'true' }}
         run: |
-          cd $GITHUB_WORKSPACE/BugSigDBExports
           ROW_COUNTS=""
           for file in full_dump.csv *.gmt; do
-            OLD_ROWS=$(git show origin/release:$file | tail -n +2 | wc -l)
-            NEW_ROWS=$(tail -n +2 $file | wc -l)
+            OLD_ROWS=$(tail -n +2 $GITHUB_WORKSPACE/BugSigDBExports-release/$file | wc -l)
+            NEW_ROWS=$(tail -n +2 $GITHUB_WORKSPACE/BugSigDBExports/$file | wc -l)
             DIFF=$((NEW_ROWS - OLD_ROWS))
             echo "$file: $OLD_ROWS -> $NEW_ROWS (+$DIFF)"
             ROW_COUNTS="$ROW_COUNTS\n    o $file: $NEW_ROWS rows ($DIFF new)"
@@ -166,7 +175,7 @@ jobs:
       - name: Update NEWS
         if: ${{ github.event.inputs.release == 'true' }}
         run: |
-          cd $GITHUB_WORKSPACE/BugSigDBExports
+          cd $GITHUB_WORKSPACE/BugSigDBExports-release
           NEWS_CONTENT="CHANGES IN VERSION ${{ github.event.inputs.version }}\n------------------------\n\nNEW DATA\n\n${{ env.ROW_COUNTS }}\n"
           if [ -n "${{ github.event.inputs.news }}" ]; then
             NEWS_CONTENT="$NEWS_CONTENT\n${{ github.event.inputs.news }}\n"
@@ -178,7 +187,11 @@ jobs:
         id: commit_exports
         if: ${{ github.event.inputs.dryrun != 'true' }}
         run: |
-          cd $GITHUB_WORKSPACE/BugSigDBExports
+          WORK_DIR=$GITHUB_WORKSPACE/BugSigDBExports
+          if [ "${{ github.event.inputs.release }}" == "true" ]; then
+            WORK_DIR=$GITHUB_WORKSPACE/BugSigDBExports-release
+          fi
+          cd $WORK_DIR
           for export in `find . -type f -iname \*.gmt -o -iname \*.csv -o -iname NEWS`
           do
             export=$(echo $export | sed 's/\.\///g')
@@ -209,7 +222,7 @@ jobs:
       - name: Tag release
         if: ${{ github.event.inputs.release == 'true' && github.event.inputs.dryrun == 'false' && github.event.inputs.version != '' }}
         run: |
-          cd $GITHUB_WORKSPACE/BugSigDBExports
+          cd $GITHUB_WORKSPACE/BugSigDBExports-release
           git tag ${{ github.event.inputs.version }}
           git push origin ${{ github.event.inputs.version }}
 

--- a/.github/workflows/export-bugsigdb.yml
+++ b/.github/workflows/export-bugsigdb.yml
@@ -62,23 +62,27 @@ jobs:
                       col.names = FALSE,
                       row.names = FALSE)
           # Keep only last 30 days
-          df <- read.csv("file_size.csv", header=FALSE)
+          df <- read.table("file_size.csv", header=TRUE)
           df$date <- as.Date(df[,1], format="%Y-%m-%d")
           df <- df[df$date >= Sys.Date() - 30, ]
           df$date <- NULL
-          write.table(df, "file_size.csv", col.names=FALSE, row.names=FALSE)
+          write.table(df, "file_size.csv", col.names=TRUE, row.names=FALSE)
         shell: Rscript {0}
 
       - name: Check for dramatic row count drop
         run: |
-          cd $GITHUB_WORKSPACE/BugSigDBExports
           Rscript -e "
-            df <- read.csv('file_size.csv', header = FALSE)
-            full_dump_col <- which(as.character(df[1,]) == 'full_dump.csv')
+            path <- file.path(Sys.getenv('GITHUB_WORKSPACE'), 'BugSigDBExports', 'file_size.csv')
+            df <- read.table(path, header = TRUE)
+            print(head(df, 2))
+            full_dump_col <- which(colnames(df) == 'full_dump.csv')
+            print(paste('full_dump_col:', full_dump_col))
+            print(paste('nrow:', nrow(df)))
             if (length(full_dump_col) > 0 && nrow(df) > 1) {
               current <- as.numeric(df[nrow(df), full_dump_col])
               previous <- as.numeric(df[nrow(df)-1, full_dump_col])
               drop_pct <- (previous - current) / previous * 100
+              print(paste('drop_pct:', drop_pct))
               if (drop_pct > 10) {
                 cat(sprintf('DROP_DETECTED=true\nDROP_PCT=%.1f\n', drop_pct),
                     file = Sys.getenv('GITHUB_ENV'), append = TRUE)

--- a/.github/workflows/release-bugsigdb.yml
+++ b/.github/workflows/release-bugsigdb.yml
@@ -123,7 +123,7 @@ jobs:
         if: ${{ steps.check_new_data.outputs.has_new_data == 'true' }}
         run: |
           cd $GITHUB_WORKSPACE/BugSigDBExports-release
-          NEWS_CONTENT="CHANGES IN VERSION ${{ github.event.inputs.version }}\n------------------------\nNEW DATA\n\n${{ env.ROW_COUNTS }}\n"
+          NEWS_CONTENT="CHANGES IN VERSION ${{ github.event.inputs.version }}\n------------------------\nNEW DATA\n${{ env.ROW_COUNTS }}\n"
           if [ -n "${{ github.event.inputs.news }}" ]; then
             NEWS_CONTENT="$NEWS_CONTENT\n${{ github.event.inputs.news }}\n"
           fi
@@ -205,25 +205,6 @@ jobs:
               \"prerelease\": false
             }" | python3 -c 'import json,sys; print(json.load(sys.stdin)["id"])')
           echo "RELEASE_ID=$RELEASE_ID" >> $GITHUB_ENV
-
-      - name: Upload release assets
-        if: ${{ steps.check_new_data.outputs.has_new_data == 'true' && github.event.inputs.dryrun == 'false' }}
-        run: |
-          for file in $GITHUB_WORKSPACE/BugSigDBExports-release/full_dump.csv \
-                      $GITHUB_WORKSPACE/BugSigDBExports-release/bugsigdb_signatures_*.gmt \
-                      $GITHUB_WORKSPACE/BugSigDBExports-release/NEWS; do
-            filename=$(basename $file)
-            echo "Uploading $filename..."
-            if ! curl --fail -X POST \
-              -H "Authorization: token ${{ secrets.GITHUB_TOKEN }}" \
-              -H "Content-Type: application/octet-stream" \
-              "https://uploads.github.com/repos/${{ github.repository }}/releases/${{ env.RELEASE_ID }}/assets?name=$filename" \
-              --data-binary @$file; then
-              echo "Failed to upload $filename"
-              exit 1
-            fi
-            echo "Successfully uploaded $filename"
-          done
 
       - name: Publish GitHub Release
         if: ${{ steps.check_new_data.outputs.has_new_data == 'true' && github.event.inputs.dryrun == 'false' }}

--- a/.github/workflows/release-bugsigdb.yml
+++ b/.github/workflows/release-bugsigdb.yml
@@ -27,19 +27,6 @@ jobs:
 
     steps:
 
-      - name: Validate version format
-        run: |
-          TAG="${{ github.event.inputs.version }}"
-          if [[ ! "$TAG" =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
-            echo "Invalid tag format. Must be v[major].[minor].[patch] e.g. v1.3.1"
-            exit 1
-          fi
-          if git ls-remote --tags origin "$TAG" | grep -q "$TAG"; then
-            echo "Tag $TAG already exists"
-            exit 1
-          fi
-          echo "VERSION=$TAG" >> $GITHUB_ENV
-
       - name: Checkout BugSigDBExports devel
         uses: actions/checkout@v3
         with:
@@ -52,6 +39,20 @@ jobs:
           ref: release
           path: BugSigDBExports-release
           fetch-depth: 1
+
+      - name: Validate version format
+        run: |
+          cd $GITHUB_WORKSPACE/BugSigDBExports-release
+          TAG="${{ github.event.inputs.version }}"
+          if ! echo "$TAG" | grep -qE '^v[0-9]+\.[0-9]+\.[0-9]+$'; then
+            echo "Invalid tag format. Must be v[major].[minor].[patch] e.g. v1.3.1"
+            exit 1
+          fi
+          if git ls-remote --tags origin "$TAG" | grep -q "$TAG"; then
+            echo "Tag $TAG already exists"
+            exit 1
+          fi
+          echo "VERSION=$TAG" >> $GITHUB_ENV
 
       - name: Install BugSigDBExports dependencies
         run: |
@@ -100,13 +101,26 @@ jobs:
           echo "" >> $GITHUB_ENV
           echo "EOF" >> $GITHUB_ENV
 
+      - name: Check for new data
+        id: check_new_data
+        run: |
+          OLD_ROWS=$(tail -n +2 $GITHUB_WORKSPACE/BugSigDBExports-release/full_dump.csv | wc -l)
+          NEW_ROWS=$(tail -n +2 $GITHUB_WORKSPACE/BugSigDBExports/full_dump.csv | wc -l)
+          if [ "$OLD_ROWS" = "$NEW_ROWS" ]; then
+            echo "No changes to full_dump.csv since last release."
+            echo "has_new_data=false" >> $GITHUB_OUTPUT
+          else
+            echo "has_new_data=true" >> $GITHUB_OUTPUT
+          fi
+
       - name: Copy exports to release
+        if: ${{ steps.check_new_data.outputs.has_new_data == 'true' }}
         run: |
           cp $GITHUB_WORKSPACE/BugSigDBExports/full_dump.csv $GITHUB_WORKSPACE/BugSigDBExports-release/
           cp $GITHUB_WORKSPACE/BugSigDBExports/*.gmt $GITHUB_WORKSPACE/BugSigDBExports-release/
-          cp $GITHUB_WORKSPACE/BugSigDBExports/file_size.csv $GITHUB_WORKSPACE/BugSigDBExports-release/
 
       - name: Update NEWS
+        if: ${{ steps.check_new_data.outputs.has_new_data == 'true' }}
         run: |
           cd $GITHUB_WORKSPACE/BugSigDBExports-release
           NEWS_CONTENT="CHANGES IN VERSION ${{ github.event.inputs.version }}\n------------------------\nNEW DATA\n\n${{ env.ROW_COUNTS }}\n"
@@ -117,7 +131,7 @@ jobs:
           printf "$NEWS_CONTENT" | cat - NEWS > NEWS.tmp && mv NEWS.tmp NEWS
 
       - name: Stage artifacts
-        if: ${{ github.event.inputs.dryrun == 'true' }}
+        if: ${{ steps.check_new_data.outputs.has_new_data == 'true' && github.event.inputs.dryrun == 'true' }}
         run: |
           mkdir -p /tmp/artifacts
           cp $GITHUB_WORKSPACE/BugSigDBExports-release/full_dump.csv /tmp/artifacts/
@@ -126,7 +140,7 @@ jobs:
           ls /tmp/artifacts/
 
       - name: Upload release candidate artifacts
-        if: ${{ github.event.inputs.dryrun == 'true' }}
+        if: ${{ steps.check_new_data.outputs.has_new_data == 'true' && github.event.inputs.dryrun == 'true' }}
         uses: actions/upload-artifact@v4
         with:
           name: candidate
@@ -134,7 +148,7 @@ jobs:
           retention-days: 90
 
       - name: Post run summary
-        if: ${{ github.event.inputs.dryrun == 'true' }}
+        if: ${{ steps.check_new_data.outputs.has_new_data == 'true' && github.event.inputs.dryrun == 'true' }}
         run: |
           echo "## Release candidate ${{ github.event.inputs.version }}" >> $GITHUB_STEP_SUMMARY
           echo "* Artifacts are available for download on this run's page." >> $GITHUB_STEP_SUMMARY
@@ -143,7 +157,7 @@ jobs:
 
       - name: Commit Exports
         id: commit_exports
-        if: ${{ github.event.inputs.dryrun == 'false' }}
+        if: ${{ steps.check_new_data.outputs.has_new_data == 'true' && github.event.inputs.dryrun == 'false' }}
         run: |
           cd $GITHUB_WORKSPACE/BugSigDBExports-release
           for export in `find . -type f -iname \*.gmt -o -iname \*.csv -o -iname NEWS`
@@ -160,7 +174,6 @@ jobs:
           echo "Check if any file contents have added to the index"
           has_updates=$(git diff --cached --shortstat)
           if [ -n "$has_updates" ]; then
-            git add file_size.csv
             git commit -m "Release ${{ github.event.inputs.version }}"
             git push -u origin HEAD
             echo "pushed=true" >> $GITHUB_OUTPUT
@@ -170,17 +183,17 @@ jobs:
           fi
 
       - name: Tag release
-        if: ${{ github.event.inputs.dryrun == 'false' }}
+        if: ${{ steps.check_new_data.outputs.has_new_data == 'true' && github.event.inputs.dryrun == 'false' }}
         run: |
           cd $GITHUB_WORKSPACE/BugSigDBExports-release
           git tag ${{ github.event.inputs.version }}
           git push origin ${{ github.event.inputs.version }}
 
       - name: Create GitHub Release
-        if: ${{ github.event.inputs.dryrun == 'false' }}
+        if: ${{ steps.check_new_data.outputs.has_new_data == 'true' && github.event.inputs.dryrun == 'false' }}
         run: |
           NEWS_BODY=$(sed -n "/^CHANGES IN VERSION ${{ github.event.inputs.version }}/,/^CHANGES IN VERSION/{ /^CHANGES IN VERSION ${{ github.event.inputs.version }}/d; /^CHANGES IN VERSION/d; p }" $GITHUB_WORKSPACE/BugSigDBExports-release/NEWS)
-          curl -X POST \
+          RELEASE_ID=$(curl -X POST \
             -H "Authorization: token ${{ secrets.GITHUB_TOKEN }}" \
             -H "Accept: application/vnd.github.v3+json" \
             https://api.github.com/repos/${{ github.repository }}/releases \
@@ -188,6 +201,35 @@ jobs:
               \"tag_name\": \"${{ github.event.inputs.version }}\",
               \"name\": \"${{ github.event.inputs.version }}\",
               \"body\": $(echo "$NEWS_BODY" | python3 -c 'import json,sys; print(json.dumps(sys.stdin.read()))'),
-              \"draft\": false,
+              \"draft\": true,
               \"prerelease\": false
-            }"
+            }" | python3 -c 'import json,sys; print(json.load(sys.stdin)["id"])')
+          echo "RELEASE_ID=$RELEASE_ID" >> $GITHUB_ENV
+
+      - name: Upload release assets
+        if: ${{ steps.check_new_data.outputs.has_new_data == 'true' && github.event.inputs.dryrun == 'false' }}
+        run: |
+          for file in $GITHUB_WORKSPACE/BugSigDBExports-release/full_dump.csv \
+                      $GITHUB_WORKSPACE/BugSigDBExports-release/bugsigdb_signatures_*.gmt \
+                      $GITHUB_WORKSPACE/BugSigDBExports-release/NEWS; do
+            filename=$(basename $file)
+            echo "Uploading $filename..."
+            if ! curl --fail -X POST \
+              -H "Authorization: token ${{ secrets.GITHUB_TOKEN }}" \
+              -H "Content-Type: application/octet-stream" \
+              "https://uploads.github.com/repos/${{ github.repository }}/releases/${{ env.RELEASE_ID }}/assets?name=$filename" \
+              --data-binary @$file; then
+              echo "Failed to upload $filename"
+              exit 1
+            fi
+            echo "Successfully uploaded $filename"
+          done
+
+      - name: Publish GitHub Release
+        if: ${{ steps.check_new_data.outputs.has_new_data == 'true' && github.event.inputs.dryrun == 'false' }}
+        run: |
+          curl -X PATCH \
+            -H "Authorization: token ${{ secrets.GITHUB_TOKEN }}" \
+            -H "Accept: application/vnd.github.v3+json" \
+            https://api.github.com/repos/${{ github.repository }}/releases/${{ env.RELEASE_ID }} \
+            -d '{"draft": false}'

--- a/.github/workflows/release-bugsigdb.yml
+++ b/.github/workflows/release-bugsigdb.yml
@@ -1,0 +1,193 @@
+on:
+  workflow_dispatch:
+    inputs:
+      dryrun:
+        description: "Dry run — inspect artifacts before committing"
+        required: false
+        default: 'true'
+        type: choice
+        options:
+          - 'false'
+          - 'true'
+      version:
+        description: "Specify version tag e.g. v1.3.2"
+        required: true
+        type: string
+      news:
+        description: "Enter NEWS file updates (optional)"
+        required: false
+        type: string
+
+name: Release BugSigDB
+
+jobs:
+  release-bugsigdb:
+    runs-on: ubuntu-latest
+    container: bioconductor/bioconductor_docker:devel
+
+    steps:
+
+      - name: Validate version format
+        run: |
+          TAG="${{ github.event.inputs.version }}"
+          if [[ ! "$TAG" =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+            echo "Invalid tag format. Must be v[major].[minor].[patch] e.g. v1.3.1"
+            exit 1
+          fi
+          if git ls-remote --tags origin "$TAG" | grep -q "$TAG"; then
+            echo "Tag $TAG already exists"
+            exit 1
+          fi
+          echo "VERSION=$TAG" >> $GITHUB_ENV
+
+      - name: Checkout BugSigDBExports devel
+        uses: actions/checkout@v3
+        with:
+          path: BugSigDBExports
+          fetch-depth: 1
+
+      - name: Checkout BugSigDBExports release branch
+        uses: actions/checkout@v3
+        with:
+          ref: release
+          path: BugSigDBExports-release
+          fetch-depth: 1
+
+      - name: Install BugSigDBExports dependencies
+        run: |
+          pkgs <- c('rvest', 'readr', 'plyr', 'BiocFileCache', 'R.utils', 'testthat', 'stringr', 'lubridate', 'dplyr')
+          BiocManager::install(pkgs)
+        shell: Rscript {0}
+
+      - name: Install bugsigdbr
+        run: |
+          Rscript -e "BiocManager::install('bugsigdbr')"
+
+      - name: Setup git config for release
+        run: |
+          cd $GITHUB_WORKSPACE/BugSigDBExports-release
+          git config user.name "GitHub Actions Bot"
+          git config user.email "actions@github.com"
+
+      - name: Export BugSigDB
+        id: export
+        run: |
+          BUGSIGDB_TIMESTAMP="$(date -u +%Y-%m-%d_%H:%M_UTC)"
+          echo "BUGSIGDB_TIMESTAMP=$BUGSIGDB_TIMESTAMP" >> $GITHUB_ENV
+          echo $BUGSIGDB_TIMESTAMP
+          Rscript $GITHUB_WORKSPACE/BugSigDBExports/inst/scripts/dump_release.R $BUGSIGDB_TIMESTAMP $GITHUB_WORKSPACE/BugSigDBExports true
+          mv *csv $GITHUB_WORKSPACE/BugSigDBExports
+        timeout-minutes: 10
+
+      - name: Count new rows
+        run: |
+          cd $GITHUB_WORKSPACE/BugSigDBExports
+          ROW_COUNTS=""
+          for file in full_dump.csv bugsigdb_signatures_*.gmt; do
+            OLD_ROWS=$(tail -n +2 $GITHUB_WORKSPACE/BugSigDBExports-release/$file | wc -l)
+            NEW_ROWS=$(tail -n +2 $GITHUB_WORKSPACE/BugSigDBExports/$file | wc -l)
+            DIFF=$((NEW_ROWS - OLD_ROWS))
+            if [ $DIFF -ge 0 ]; then
+              DIFF_STR="+$DIFF"
+            else
+              DIFF_STR="$DIFF"
+            fi
+            echo "$file: $OLD_ROWS -> $NEW_ROWS ($DIFF_STR)"
+            ROW_COUNTS="$ROW_COUNTS\n    o $file: $NEW_ROWS rows ($DIFF_STR)"
+          done
+          echo "ROW_COUNTS<<EOF" >> $GITHUB_ENV
+          printf "$ROW_COUNTS" >> $GITHUB_ENV
+          echo "" >> $GITHUB_ENV
+          echo "EOF" >> $GITHUB_ENV
+
+      - name: Copy exports to release
+        run: |
+          cp $GITHUB_WORKSPACE/BugSigDBExports/full_dump.csv $GITHUB_WORKSPACE/BugSigDBExports-release/
+          cp $GITHUB_WORKSPACE/BugSigDBExports/*.gmt $GITHUB_WORKSPACE/BugSigDBExports-release/
+          cp $GITHUB_WORKSPACE/BugSigDBExports/file_size.csv $GITHUB_WORKSPACE/BugSigDBExports-release/
+
+      - name: Update NEWS
+        run: |
+          cd $GITHUB_WORKSPACE/BugSigDBExports-release
+          NEWS_CONTENT="CHANGES IN VERSION ${{ github.event.inputs.version }}\n------------------------\nNEW DATA\n\n${{ env.ROW_COUNTS }}\n"
+          if [ -n "${{ github.event.inputs.news }}" ]; then
+            NEWS_CONTENT="$NEWS_CONTENT\n${{ github.event.inputs.news }}\n"
+          fi
+          NEWS_CONTENT="$NEWS_CONTENT\n"
+          printf "$NEWS_CONTENT" | cat - NEWS > NEWS.tmp && mv NEWS.tmp NEWS
+
+      - name: Stage artifacts
+        if: ${{ github.event.inputs.dryrun == 'true' }}
+        run: |
+          mkdir -p /tmp/artifacts
+          cp $GITHUB_WORKSPACE/BugSigDBExports-release/full_dump.csv /tmp/artifacts/
+          cp $GITHUB_WORKSPACE/BugSigDBExports-release/bugsigdb_signatures_*.gmt /tmp/artifacts/
+          cp $GITHUB_WORKSPACE/BugSigDBExports-release/NEWS /tmp/artifacts/
+          ls /tmp/artifacts/
+
+      - name: Upload release candidate artifacts
+        if: ${{ github.event.inputs.dryrun == 'true' }}
+        uses: actions/upload-artifact@v4
+        with:
+          name: candidate
+          path: /tmp/artifacts/
+          retention-days: 90
+
+      - name: Post run summary
+        if: ${{ github.event.inputs.dryrun == 'true' }}
+        run: |
+          echo "## Release candidate ${{ github.event.inputs.version }}" >> $GITHUB_STEP_SUMMARY
+          echo "* Artifacts are available for download on this run's page." >> $GITHUB_STEP_SUMMARY
+          echo "* If the data looks good, trigger the workflow again with \`dryrun\` set to \`false\` and the same tag \`${{ github.event.inputs.version }}\`." >> $GITHUB_STEP_SUMMARY
+          echo "* Add content to NEWS with \`news\`." >> $GITHUB_STEP_SUMMARY
+
+      - name: Commit Exports
+        id: commit_exports
+        if: ${{ github.event.inputs.dryrun == 'false' }}
+        run: |
+          cd $GITHUB_WORKSPACE/BugSigDBExports-release
+          for export in `find . -type f -iname \*.gmt -o -iname \*.csv -o -iname NEWS`
+          do
+            export=$(echo $export | sed 's/\.\///g')
+            git_diff=$(git diff --numstat $export | sed -e 's/\t//g')
+            if [ "$git_diff" = "11$export" -o "$git_diff" = "" ]; then
+                echo "No changes to commit for $export"
+            else
+                echo "Add changes for $export"
+                git add $export
+            fi
+          done
+          echo "Check if any file contents have added to the index"
+          has_updates=$(git diff --cached --shortstat)
+          if [ -n "$has_updates" ]; then
+            git add file_size.csv
+            git commit -m "Release ${{ github.event.inputs.version }}"
+            git push -u origin HEAD
+            echo "pushed=true" >> $GITHUB_OUTPUT
+          else
+            echo "No content changes to commit"
+            echo "pushed=false" >> $GITHUB_OUTPUT
+          fi
+
+      - name: Tag release
+        if: ${{ github.event.inputs.dryrun == 'false' }}
+        run: |
+          cd $GITHUB_WORKSPACE/BugSigDBExports-release
+          git tag ${{ github.event.inputs.version }}
+          git push origin ${{ github.event.inputs.version }}
+
+      - name: Create GitHub Release
+        if: ${{ github.event.inputs.dryrun == 'false' }}
+        run: |
+          NEWS_BODY=$(sed -n "/^CHANGES IN VERSION ${{ github.event.inputs.version }}/,/^CHANGES IN VERSION/{ /^CHANGES IN VERSION ${{ github.event.inputs.version }}/d; /^CHANGES IN VERSION/d; p }" $GITHUB_WORKSPACE/BugSigDBExports-release/NEWS)
+          curl -X POST \
+            -H "Authorization: token ${{ secrets.GITHUB_TOKEN }}" \
+            -H "Accept: application/vnd.github.v3+json" \
+            https://api.github.com/repos/${{ github.repository }}/releases \
+            -d "{
+              \"tag_name\": \"${{ github.event.inputs.version }}\",
+              \"name\": \"${{ github.event.inputs.version }}\",
+              \"body\": $(echo "$NEWS_BODY" | python3 -c 'import json,sys; print(json.dumps(sys.stdin.read()))'),
+              \"draft\": false,
+              \"prerelease\": false
+            }"

--- a/RELEASE_PROCESS.md
+++ b/RELEASE_PROCESS.md
@@ -1,0 +1,108 @@
+# Release Process
+
+This document describes how to create a new release of BugSigDBExports.
+
+## Overview
+
+BugSigDBExports has two long-lived branches:
+
+- **`devel`** — unfiltered files, updated hourly by a GitHub Action workflow
+- **`release`** — quailty-control-filtered files, updated only on release
+
+Each release is also tagged (e.g. `v1.3.2`) for permanent, citable access.
+Tags point to a specific commit on `release` and never change.
+
+## Prerequisites
+
+Before making a release:
+
+- Confirm you have write access to the repository
+- Decide on a version tag in the format `vMAJOR.MINOR.PATCH` (e.g. `v1.3.2`)
+- Prepare any additional NEWS content you want to include beyond the
+  automatically generated row counts (optional)
+
+## Quality Control
+
+QC filtering is applied automatically when `release=true` is set in the
+workflow. Filters are defined in `inst/scripts/dump_release.R` and remove
+incomplete signatures.
+
+Row count reductions between releases are expected and intentional when
+QC filters remove invalid signatures.
+
+## Two-Step Release Process
+
+### Step 1 — Dry Run (inspect before committing)
+
+1. Go to **Actions** → **Export BugSigDB** → **Run workflow**
+2. Set the following inputs:
+   - `release`: `true`
+   - `dryrun`: `true`
+   - `version`: your version tag e.g. `v1.3.2`
+   - `news`: optional additional NEWS content in Bioconductor plain text
+     format e.g. `NEW FEATURES\n\n    o Added new filter`
+3. Wait for the workflow to complete
+4. Download the artifact from the Actions run page (available for 90 days)
+5. Inspect the files:
+   - Check that `full_dump.csv` and the GMT files look correct
+   - Check that `NEWS` has the correct row counts and any notes you provided
+   - Verify row count changes are as expected
+6. Review the run summary posted at the bottom of the Actions run page
+
+If the data does not look correct, do not proceed to step 2. Investigate
+the issue on `devel` and repeat step 1 when ready.
+
+### Step 2 — Commit
+
+1. Go to **Actions** → **Export BugSigDB** → **Run workflow**
+2. Set the following inputs:
+   - `release`: `true`
+   - `dryrun`: `false`
+   - `version`: the same tag as step 1
+   - `news`: the same content as step 1
+3. Wait for the workflow to complete
+4. The workflow will automatically:
+   - Export and QC-filter data from `devel`
+   - Count row differences vs the previous release
+   - Write the NEWS entry with row counts and your notes
+   - Commit filtered files and NEWS to the `release` branch
+   - Create and push the version tag
+   - Create the release, which should automatically create the Zenodo entry
+
+## Finalizing the Release
+
+After the workflow completes:
+
+### GitHub Release
+
+1. Go to **Releases**
+2. Confirm the release was published with NEWS, version and appropriate tag
+
+### Zenodo
+
+1. Go to [zenodo.org](https://zenodo.org) and find the new record
+2. Verify the metadata (authors, description, keywords) is accurate
+3. Edit if necessary and save
+
+## NEWS File Format
+
+The NEWS file follows Bioconductor plain text format. The workflow
+automatically prepends a new entry on each release:
+
+```
+CHANGES IN VERSION v1.3.2
+------------------------
+
+NEW DATA
+
+    o full_dump.csv: 8421 rows (+8)
+    o bugsigdb_signatures_genus_metaphlan.gmt: 5298 rows (+15)
+    ...
+
+OPTIONAL USER-PROVIDED SECTION
+
+    o Additional notes here
+```
+
+Row counts show `+N` for additions and `-N` for removals relative to the
+previous release. Counts exclude the header row.

--- a/RELEASE_PROCESS.md
+++ b/RELEASE_PROCESS.md
@@ -23,9 +23,8 @@ Before making a release:
 
 ## Quality Control
 
-QC filtering is applied automatically when `release=true` is set in the
-workflow. Filters are defined in `inst/scripts/dump_release.R` and remove
-incomplete signatures.
+QC filtering is applied automatically when creating a release. Filters are
+defined in `inst/scripts/dump_release.R` and remove incomplete signatures.
 
 Row count reductions between releases are expected and intentional when
 QC filters remove invalid signatures.
@@ -34,9 +33,8 @@ QC filters remove invalid signatures.
 
 ### Step 1 — Dry Run (inspect before committing)
 
-1. Go to **Actions** → **Export BugSigDB** → **Run workflow**
+1. Go to **Actions** → **Release BugSigDB** → **Run workflow**
 2. Set the following inputs:
-   - `release`: `true`
    - `dryrun`: `true`
    - `version`: your version tag e.g. `v1.3.2`
    - `news`: optional additional NEWS content in Bioconductor plain text
@@ -56,7 +54,6 @@ the issue on `devel` and repeat step 1 when ready.
 
 1. Go to **Actions** → **Export BugSigDB** → **Run workflow**
 2. Set the following inputs:
-   - `release`: `true`
    - `dryrun`: `false`
    - `version`: the same tag as step 1
    - `news`: the same content as step 1


### PR DESCRIPTION
Updates action to
- create releases with quality control that automatically update the NEWS file with row diffs
- create artifacts (tarball of files to be included) dryruns of potential releases
- truncate file_size and open an issue if there's a 10% drop in file size

Follows a release strategy of making commits to a long-lived release branch that gets tagged with versions. ~~Releases still need to put into Zenodo manually. Needs documentation.~~

Partially written and debugged with Claude.