### PR TITLE
Use MediaWiki API prop=extlinks with User-Agent to resolve export URLs

### DIFF
--- a/inst/scripts/dump_release.R
+++ b/inst/scripts/dump_release.R
@@ -47,10 +47,50 @@ valid_pmid <- function(x)
 
 ## FUNCTIONS
 
-getBugSigDBExportURLs <- function(help_url = "https://bugsigdb.org/Help:Export")
+getBugSigDBExportURLs <- function(api_url = "https://bugsigdb.org/w/api.php",
+                                  help_url = "https://bugsigdb.org/Help:Export")
 {
+    user_agent <- "BugSigDBExports/1.0 (https://github.com/waldronlab/BugSigDBExports)"
+
+    # 1. Primary approach: MediaWiki API prop=extlinks with informative User-Agent
+    urls <- tryCatch({
+        req <- httr2::request(api_url) |>
+            httr2::req_url_query(
+                action = "query",
+                titles = "Help:Export",
+                prop = "extlinks",
+                format = "json"
+            ) |>
+            httr2::req_user_agent(user_agent) |>
+            httr2::req_retry(max_tries = 3, backoff = ~ 5)
+
+        resp <- httr2::req_perform(req)
+        data <- httr2::resp_body_json(resp)
+        pages <- data[["query"]][["pages"]]
+        extlinks <- unlist(lapply(pages[[1]][["extlinks"]], function(x) x[[1]]))
+
+        list(
+            stud = grep("studies.csv", extlinks, value = TRUE, fixed = TRUE)[1L],
+            exp  = grep("experiments.csv", extlinks, value = TRUE, fixed = TRUE)[1L],
+            sig  = grep("signatures.csv", extlinks, value = TRUE, fixed = TRUE)[1L]
+        )
+    }, error = function(e) {
+        warning(sprintf(
+            "MediaWiki API query failed: %s. Falling back to HTML scraping.",
+            e$message))
+        NULL
+    })
+
+    if (!is.null(urls) && !is.na(urls$stud) && !is.na(urls$exp) && !is.na(urls$sig)) {
+        return(urls)
+    }
+
+    # 2. Fallback: HTML scraping of Help:Export
     req <- tryCatch(
-        httr2::request(help_url) |> httr2::req_perform(),
+        httr2::request(help_url) |>
+            httr2::req_user_agent(user_agent) |>
+            httr2::req_retry(max_tries = 3, backoff = ~ 5) |>
+            httr2::req_perform(),
         error = function(e) stop(sprintf(
             "Failed to reach export page '%s': %s", help_url, e$message))
     )
@@ -58,7 +98,7 @@ getBugSigDBExportURLs <- function(help_url = "https://bugsigdb.org/Help:Export")
     links <- html |> rvest::html_elements("a") |> rvest::html_attr("href")
 
     extract_url <- function(pattern) {
-        target <- grep(pattern, links, value = TRUE)
+        target <- grep(pattern, links, value = TRUE, fixed = TRUE)
         if (length(target) == 0L)
             stop(sprintf(
                 "Failed to resolve export URL matching pattern '%s' from %s",
@@ -67,9 +107,9 @@ getBugSigDBExportURLs <- function(help_url = "https://bugsigdb.org/Help:Export")
     }
 
     list(
-        stud = extract_url("studies\\.csv$"),
-        exp  = extract_url("experiments\\.csv$"),
-        sig  = extract_url("signatures\\.csv$")
+        stud = extract_url("studies.csv"),
+        exp  = extract_url("experiments.csv"),
+        sig  = extract_url("signatures.csv")
     )
 }
 
@@ -142,7 +182,7 @@ downloadFiles <- function(links, delay = 60, max.attempts = 3)
                 download.file(url,
                               destfile = destfile,
                               method = "curl",
-                              extra = "--limit-rate 50K")
+                              extra = '--limit-rate 50K -A "BugSigDBExports/1.0 (https://github.com/waldronlab/BugSigDBExports)"')
                 if (!is_valid_csv(destfile)) {
                     stop(paste("Downloaded file is not a valid BugSigDB CSV:",
                                download_diagnostics(csv, url, destfile)))

--- a/inst/scripts/dump_release.R
+++ b/inst/scripts/dump_release.R
@@ -45,13 +45,17 @@ valid_pmid <- function(x)
     stringr::str_detect(x, "^[0-9]{8,8}$")
 
 
+## CONSTANTS
+
+DEFAULT_USER_AGENT <- "BugSigDBExports/1.0 (https://github.com/waldronlab/BugSigDBExports)"
+
+
 ## FUNCTIONS
 
 getBugSigDBExportURLs <- function(api_url = "https://bugsigdb.org/w/api.php",
-                                  help_url = "https://bugsigdb.org/Help:Export")
+                                  help_url = "https://bugsigdb.org/Help:Export",
+                                  user_agent = DEFAULT_USER_AGENT)
 {
-    user_agent <- "BugSigDBExports/1.0 (https://github.com/waldronlab/BugSigDBExports)"
-
     # 1. Primary approach: MediaWiki API prop=extlinks with informative User-Agent
     urls <- tryCatch({
         req <- httr2::request(api_url) |>
@@ -70,9 +74,9 @@ getBugSigDBExportURLs <- function(api_url = "https://bugsigdb.org/w/api.php",
         extlinks <- unlist(lapply(pages[[1]][["extlinks"]], function(x) x[[1]]))
 
         list(
-            stud = grep("studies.csv", extlinks, value = TRUE, fixed = TRUE)[1L],
-            exp  = grep("experiments.csv", extlinks, value = TRUE, fixed = TRUE)[1L],
-            sig  = grep("signatures.csv", extlinks, value = TRUE, fixed = TRUE)[1L]
+            stud = grep("studies\\.csv(?:$|\\?)", extlinks, value = TRUE)[1L],
+            exp  = grep("experiments\\.csv(?:$|\\?)", extlinks, value = TRUE)[1L],
+            sig  = grep("signatures\\.csv(?:$|\\?)", extlinks, value = TRUE)[1L]
         )
     }, error = function(e) {
         warning(sprintf(
@@ -98,7 +102,7 @@ getBugSigDBExportURLs <- function(api_url = "https://bugsigdb.org/w/api.php",
     links <- html |> rvest::html_elements("a") |> rvest::html_attr("href")
 
     extract_url <- function(pattern) {
-        target <- grep(pattern, links, value = TRUE, fixed = TRUE)
+        target <- grep(pattern, links, value = TRUE)
         if (length(target) == 0L)
             stop(sprintf(
                 "Failed to resolve export URL matching pattern '%s' from %s",
@@ -107,13 +111,13 @@ getBugSigDBExportURLs <- function(api_url = "https://bugsigdb.org/w/api.php",
     }
 
     list(
-        stud = extract_url("studies.csv"),
-        exp  = extract_url("experiments.csv"),
-        sig  = extract_url("signatures.csv")
+        stud = extract_url("studies\\.csv(?:$|\\?)"),
+        exp  = extract_url("experiments\\.csv(?:$|\\?)"),
+        sig  = extract_url("signatures\\.csv(?:$|\\?)")
     )
 }
 
-downloadFiles <- function(links, delay = 60, max.attempts = 3)
+downloadFiles <- function(links, delay = 60, max.attempts = 3, user_agent = DEFAULT_USER_AGENT)
 {
     # Required in all expected BugSigDB CSV exports; used as validation sentinel.
     required.column <- "State"
@@ -182,7 +186,7 @@ downloadFiles <- function(links, delay = 60, max.attempts = 3)
                 download.file(url,
                               destfile = destfile,
                               method = "curl",
-                              extra = '--limit-rate 50K -A "BugSigDBExports/1.0 (https://github.com/waldronlab/BugSigDBExports)"')
+                              extra = sprintf('--limit-rate 50K -A "%s"', user_agent))
                 if (!is_valid_csv(destfile)) {
                     stop(paste("Downloaded file is not a valid BugSigDB CSV:",
                                download_diagnostics(csv, url, destfile)))


### PR DESCRIPTION
### Description

This PR enhances the export URL resolution in `inst/scripts/dump_release.R` by querying MediaWiki's structured `prop=extlinks` API instead of relying solely on HTML scraping:

1. **MediaWiki API Endpoint**: Calls `https://bugsigdb.org/w/api.php?action=query&titles=Help:Export&prop=extlinks&format=json` to fetch parsed external links directly from MediaWiki's index.
2. **Explicit User-Agent Header**: Adds `User-Agent: BugSigDBExports/1.0 (https://github.com/waldronlab/BugSigDBExports)` in `httr2` and `download.file` (curl) to adhere to MediaWiki API etiquette and prevent 403 Forbidden / bot-protection blocks from Cloudflare/Varnish.
3. **Resilient Fallback**: If the API call fails or is unavailable, the function falls back to scraping `https://bugsigdb.org/Help:Export` HTML.

### Verification
- Tested MediaWiki API query locally with `httr2`; successfully resolved `studies.csv`, `experiments.csv`, and `signatures.csv` URLs.
- Verified download headers and syntax.